### PR TITLE
Custom dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ plugins:
     my_dashboard:
       title: My Dashboard
       description: Showing some nice metrics
+      layout:
+        - [chart1]
+        - [chart2]
       charts:
         - title: Number of events by day
           db: jobs
@@ -59,6 +62,13 @@ To display [Vega](https://vega.github.io/vega-lite/docs/) charts:
   - Some fields are pre-defined: `$schema`, `title`, `width`, `view`, `config`, `data`
   - All fields are passed along as-is (overriding pre-defined fields if any)
   - Only `mark` and `encoding` fields are required as the bare-minimum
+
+The default dashboard layout will present two charts per row (one per row on mobile).
+To make use of custom dashboard layout using [CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout),
+define the `layout` array property such as:
+
+- Each entry represents a row of charts
+- Each column is referred by the 1-indexed chart in the list (e.g. "chart1", "chart2, etc.)
 
 A new menu entry is now available, pointing at `/-/dashboards` to access all defined dashboards.
 

--- a/datasette_dashboards/static/dashboards.css
+++ b/datasette_dashboards/static/dashboards.css
@@ -1,6 +1,7 @@
 .dashboard-grid {
   display: grid;
-  grid-auto-rows: minmax(100px, auto);
+  grid-auto-columns: minmax(100px, 1fr);
+  grid-auto-rows: minmax(100px, 1fr);
   grid-gap: 0.5rem;
 }
 
@@ -23,4 +24,5 @@
 
 .dashboard-card-chart {
   width: 100%;
+  height: 100%;
 }

--- a/datasette_dashboards/static/dashboards.css
+++ b/datasette_dashboards/static/dashboards.css
@@ -4,12 +4,6 @@
   grid-gap: 0.5rem;
 }
 
-@media (min-width: 640px) {
-  .dashboard-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
 .dashboard-card {
   background-color: white;
   padding: 1rem;

--- a/datasette_dashboards/static/dashboards.css
+++ b/datasette_dashboards/static/dashboards.css
@@ -1,7 +1,13 @@
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  grid-auto-rows: minmax(100px, auto);
   grid-gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .dashboard-card {

--- a/datasette_dashboards/static/dashboards.js
+++ b/datasette_dashboards/static/dashboards.js
@@ -1,5 +1,5 @@
-function renderVegaChart(chart, json_data_url, dom_id) {
-  var vlSpec = {
+function renderVegaChart(chart, json_data_url, el) {
+  const spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     description: chart.title,
     width: 'container',
@@ -19,5 +19,6 @@ function renderVegaChart(chart, json_data_url, dom_id) {
     },
     ...chart.display
   };
-  vegaEmbed(dom_id, vlSpec);
+
+  vegaEmbed(el, spec);
 }

--- a/datasette_dashboards/templates/dashboard_view.html
+++ b/datasette_dashboards/templates/dashboard_view.html
@@ -1,10 +1,31 @@
 {% extends "base.html" %}
 
+{% set dashboard = dashboards[slug] %}
+
 {% block title %}{{ database }}{% endblock %}
 
 {% block extra_head %}
 {{ super() }}
 <link href="{{ urls.static_plugins('datasette_dashboards', 'dashboards.css') }}" rel="stylesheet"/>
+<style>
+  @media (min-width: 640px) {
+    .dashboard-grid {
+      {% if dashboard.layout %}
+      grid-template-areas: {% for row in dashboard.layout %}"{% for col in row %}{{ col }} {% endfor %}" {% endfor %};
+      {% else %}
+      grid-template-columns: repeat(2, 1fr);
+      {% endif %}
+    }
+
+    {% if dashboard.layout %}
+    {% for chart in dashboard.charts %}
+    #card-{{ loop.index }} {
+      grid-area: chart{{ loop.index }};
+    }
+    {% endfor %}
+    {% endif %}
+  }
+</style>
 {% endblock %}
 
 {% block nav %}
@@ -18,8 +39,6 @@
 {% block body_class %}index{% endblock %}
 
 {% block content %}
-    {% set dashboard = dashboards[slug] %}
-
     <div class="dashboard-header">
       <div class="page-header" style="border-color: black">
         <h1>{{ dashboard.title }}</h1>
@@ -29,11 +48,11 @@
 
     <div class="dashboard-grid">
       {% for chart in dashboard.charts %}
-      <div class="dashboard-card">
+      <div id="card-{{ loop.index }}" class="dashboard-card">
         <div class="dashboard-card-title">
           <p><a href="/{{ chart.db }}?sql={{ chart.query }}">{{ chart.title }}</a></p>
         </div>
-        <div id="chart-{{ loop.index0 }}" class="dashboard-card-chart"></div>
+        <div id="chart-{{ loop.index }}" class="dashboard-card-chart"></div>
       </div>
       {% endfor %}
     </div>
@@ -48,7 +67,7 @@
       renderVegaChart(
         JSON.parse('{{ chart|tojson }}'),
         '/{{ chart.db }}.json?sql={{ chart.query }}&_shape=array',
-        '#chart-{{ loop.index0 }}'
+        '#chart-{{ loop.index }}'
       )
       {% endif %}
       {% endfor %}

--- a/demo/metadata.yml
+++ b/demo/metadata.yml
@@ -9,8 +9,8 @@ plugins:
       title: Job offers statistics
       description: Gather metrics about job offers
       layout:
-        - [chart1, chart1, chart4]
-        - [chart2, chart3, chart4]
+        - [chart1, chart1, chart1, chart4]
+        - [chart2, chart3, chart3, chart4]
       charts:
         - title: Number of offers by day
           db: jobs

--- a/demo/metadata.yml
+++ b/demo/metadata.yml
@@ -8,6 +8,9 @@ plugins:
     job_offers_stats:
       title: Job offers statistics
       description: Gather metrics about job offers
+      layout:
+        - [chart1, chart1, chart4]
+        - [chart2, chart3, chart4]
       charts:
         - title: Number of offers by day
           db: jobs


### PR DESCRIPTION
Implement custom dashboard layout using [CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout). The default dashboard layout will present two charts per row (one per row on mobile).

Define the `layout` array property such as:

- Each entry represents a row of charts
- Each column is referred by the 1-indexed chart in the list (e.g. "chart1", "chart2, etc.)
