### PR TITLE
docs: mention the metric library in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Common chart properties for all chart types:
 | `title`   | `string` | Chart title                                              |
 | `db`      | `string` | Database name against which to run the query             |
 | `query`   | `string` | SQL query to run and extract data from                   |
-| `library` | `string` | One of supported libraries: `vega`, `markdown`           |
+| `library` | `string` | One of supported libraries: `vega`, `markdown`, `metric` |
 | `display` | `object` | Chart display specification (depend on the used library) |
 
 To define SQL queries using dashboard filters:


### PR DESCRIPTION
## Motivation

Noticed that the "metrics" setting for `library` is used in the demo, but not documented 

https://github.com/rclement/datasette-dashboards/blob/202fb2fcbc9efe4848fe940fae435eff75bb4f59/demo/metadata.yml#L61

## Changes

- Updates README.md