### PR TITLE
Fix Python 3.11 integration for pytest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ datasette-cluster-map = "==0.17.2"
 datasette-dashboards = {editable = true, path = ".", extras = ["test"]}
 datasette-publish-vercel = "==0.14.2"
 datasette-vega = "==0.6.2"
+exceptiongroup = {version = "==1.0.4", markers = "python_version < '3.11'"}
 flake8 = "==5.0.4"
 importlib-metadata = "==5.0.0"
 pytest-cov = "==4.0.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed452a8b841ff95a549f2acbba37d6aec718948cf41fe14d1189ee63280d1371"
+            "sha256": "e7045a4a83fe40bec31a2bab1a8d7909afb277964c3aa33ad439b9a641af31b8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -238,6 +238,7 @@
                 "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
                 "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
             ],
+            "index": "pypi",
             "markers": "python_version < '3.11'",
             "version": "==1.0.4"
         },


### PR DESCRIPTION
Explicit add of `exceptiongroup` for Python < 3.11

Otherwise `pytest` will crash on Python < 3.11