### PR TITLE
Pass database as string to permission check to avoid exception

### DIFF
--- a/datasette_dashboards/__init__.py
+++ b/datasette_dashboards/__init__.py
@@ -92,7 +92,7 @@ async def dashboard_view(request, datasette):
             database = datasette.get_database(db)
         except KeyError:
             raise NotFound(f"Database does not exist: {db}")
-        await check_permission_execute_sql(request, datasette, database)
+        await check_permission_execute_sql(request, datasette, database.name)
 
     options_keys = get_dashboard_filters_keys(request, dashboard)
     query_parameters = get_dashboard_filters(request, options_keys)
@@ -134,7 +134,7 @@ async def dashboard_chart(request, datasette):
     db = chart.get("db")
     if db:
         database = datasette.get_database(db)
-        await check_permission_execute_sql(request, datasette, database)
+        await check_permission_execute_sql(request, datasette, database.name)
 
     options_keys = get_dashboard_filters_keys(request, dashboard)
     query_string = generate_dashboard_filters_qs(request, options_keys)


### PR DESCRIPTION
Without this one gets a `Database object is not subscriptable` error when used with Datasette 1.0a2.
Datasette 1.0 seems to have changed that API:
If this is a string it does the right thing internally, if not it tries to access the object at index 0.

---

datasette 1.0 is obviously in alpha state for now and I haven't checked if this code still works against older Datasette versions.
I figured I still post this PR already.