### PR TITLE
Added support for custom Vega charts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,36 @@ SELECT * FROM mytable [[ WHERE col >= :my_filter ]]
 SELECT * FROM mytable WHERE TRUE [[ AND col1 = :my_filter_1 ]] [[ AND col2 = :my_filter_2 ]]
 ```
 
-#### Vega properties
+#### Vega propertes
+
+Available configuration for `vega` charts:
+
+| Property  | Type     | Description                |
+|-----------|----------|----------------------------|
+| `library` | `string` | Must be set to `vega` |
+| `display` | `object` | Vega specification object  |
+
+Notes about the `display` property:
+
+- Requires a valid [Vega specification object](https://vega.github.io/vega/docs/)
+- Some fields are pre-defined: `$schema`, `description`, `autosize`, `data`, and `signals`
+- All fields are passed along as-is (overriding pre-defined fields if any)
+- Data property `name` is set to `table`
+- Only `scales`, `axes`, and `marks` fields are required as the bare-minimum
+
+
+#### Vega-Lite properties
 
 Available configuration for `vega` charts:
 
 | Property  | Type     | Description               |
 | --------- | -------- | ------------------------- |
-| `library` | `string` | Must be set to `vega`     |
-| `display` | `object` | Vega specification object |
+| `library` | `string` | Must be set to `vega-lite`     |
+| `display` | `object` | Vega-Lite specification object |
 
 Notes about the `display` property:
 
-- Requires a valid [Vega specification object](https://vega.github.io/vega-lite/docs/)
+- Requires a valid [Vega-Lite specification object](https://vega.github.io/vega-lite/docs/)
 - Some fields are pre-defined: `$schema`, `title`, `width`, `view`, `config`, `data`
 - All fields are passed along as-is (overriding pre-defined fields if any)
 - Only `mark` and `encoding` fields are required as the bare-minimum

--- a/datasette_dashboards/static/dashboards.js
+++ b/datasette_dashboards/static/dashboards.js
@@ -1,4 +1,45 @@
-function renderVegaChart(el, chart, query_string, height_style = undefined) {
+function renderVegaChart(el, chart, query_string){
+    const query = encodeURIComponent(chart.query)
+    const spec = {
+	$schema: 'https://vega.github.io/schema/vega/v5.json',
+	description: chart.title,
+	autosize: {'type': 'fit'},
+	data: [{
+	    name: 'table',
+	    url: `/${chart.db}.csv?sql=${query}&${query_string}`,
+	    format: {'type': 'csv', "delimiter": ","}
+	}],
+	signals: [
+	    {
+		'name': 'width',
+		'init': 'containerSize()[0]',
+		'value': '',
+		'on': [{
+		    'events': {
+			'source': 'window',
+			'type': 'resize'
+		    },
+		    'update': 'containerSize()[0]'
+		}]
+	    },
+	    {
+		'name': 'height',
+		'init': 'containerSize()[1]',
+		'value': '',
+		'on': [{
+		    'events': {
+			'source': 'window',
+			'type': 'resize'
+		    },
+		    'update': 'containerSize()[1]'
+		}]
+	    }],
+	...chart.display
+    };
+    vegaEmbed(el, spec);
+}
+
+function renderVegaLiteChart(el, chart, query_string, height_style = undefined) {
   const query = encodeURIComponent(chart.query)
   const spec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',

--- a/datasette_dashboards/templates/dashboard_chart.html
+++ b/datasette_dashboards/templates/dashboard_chart.html
@@ -50,7 +50,9 @@
     <script src="{{ urls.static_plugins('datasette_dashboards', 'dashboards.js') }}"></script>
     <script type="text/javascript">
       {% if chart.library == 'vega' %}
-      renderVegaChart('#chart', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}', 'container')
+      renderVegaChart('#chart', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}')
+      {% elif chart.library == 'vega-lite'%}
+      renderVegaLiteChart('#chart', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}', 'container')
       {% elif chart.library == 'metric' %}
       renderMetricChart('#chart', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}')
       {% endif %}

--- a/datasette_dashboards/templates/dashboard_view.html
+++ b/datasette_dashboards/templates/dashboard_view.html
@@ -96,6 +96,8 @@
       {% for chart_slug, chart in dashboard.charts.items() %}
       {% if chart.library == 'vega' %}
       renderVegaChart('#chart-{{ chart_slug }}', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}')
+      {% elif chart.library == 'vega-lite' %}
+      renderVegaLiteChart('#chart-{{ chart_slug }}', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}')
       {% elif chart.library == 'metric' %}
       renderMetricChart('#chart-{{ chart_slug }}', JSON.parse('{{ chart|tojson }}'), '{{ query_string|safe }}')
       {% endif %}


### PR DESCRIPTION
Function Name Changes:
renderVegaChart() -> renderVegaLiteChart()

Function Additions:
renderVegaChart()

Implementation Notes:
Autosizing a rendered Vega chart based on the css container dimensions is achieved by calling the Vega function 'containerSize()' which will return an array [width, height]. The chart is initialized to the dimensions and then update on any window resize events. If this part of the vega spec is missing when rendered, it will mess up how the dashboard grid is displayed. I have not checked to see if a user can accidentally overwrite this if they submit their own custom signal spec.

Added documentation to README describing functionality