### PR TITLE
fix(docs): Update vega-lite definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ plugins:
           title: Number of events by source
           db: jobs
           query: SELECT source, count(*) as count FROM events WHERE TRUE [[ AND date >= date(:date_start) ]] [[ AND date <= date(:date_end) ]] GROUP BY source ORDER BY count DESC
-          library: vega
+          library: vega-lite
           display:
-            mark: { type: bar, tooltip: true }
+            mark: { type: arc, tooltip: true }
             encoding:
               color: { field: source, type: nominal }
               theta: { field: count, type: quantitative }


### PR DESCRIPTION
## Motivation

- Improve onboarding experience for new users unfamiliar with vega-lite

## Changes

- `theta` is incompatible with `bar`, so I assumed this was meant to go with `arc` to create a donut chart.
- The example doesn't contain enough detail for `vega` spec, so I figured this was a `vega-lite` graph.

## Notes

- Spotted this while adding support for datasette-dashboards to datasette-lite: https://github.com/hydrosquall/datasette-lite/pull/9