### PR TITLE
Switch select filter to autocomplete text filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Switch `select` filter to autocomplete text filter when more than 100 options are provided
 
 ## [0.6.0] - 2023-08-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ SELECT * FROM mytable [[ WHERE col >= :my_filter ]]
 SELECT * FROM mytable WHERE TRUE [[ AND col1 = :my_filter_1 ]] [[ AND col2 = :my_filter_2 ]]
 ```
 
+**Important notes:**
+
+- When a `select` filter has more than 100 options, the dropdown list will be automatically converted to a text filter with autocompletion
+
 #### Vega properties
 
 Available configuration for `vega` charts:

--- a/datasette_dashboards/templates/dashboard_view.html
+++ b/datasette_dashboards/templates/dashboard_view.html
@@ -76,12 +76,21 @@
           <fieldset>
             <legend>{{ dfilter.name }}</legend>
             {% if dfilter_type == 'select' %}
-            <select id="{{ key }}" name="{{ key }}">
-              <option value="" {% if (key in query_parameters.keys() and query_parameters[key] == '') or  (key not in query_parameters.keys() and not dfilter.default) %}selected{% endif %}></option>
-              {% for option in dfilter.options %}
-              <option value="{{ option }}" {% if (key in query_parameters.keys() and query_parameters[key] == option) or (key not in query_parameters.keys() and dfilter.default == option) %}selected{% endif %}>{{ option }}</option>
-              {% endfor %}
-            </select>
+              {% if dfilter.options | length > 100 %}
+              <input id="{{ key }}" name="{{ key }}" type="text" list="{{ key }}-list" value="{% if key in query_parameters.keys() %}{{ query_parameters[key] }}{% else %}{{ dfilter.default }}{% endif %}">
+              <datalist id="{{ key }}-list">
+                {% for option in dfilter.options %}
+                <option value="{{ option }}">{{ option }}</option>
+                {% endfor %}
+              </datalist>
+              {% else %}
+              <select id="{{ key }}" name="{{ key }}">
+                <option value="" {% if (key in query_parameters.keys() and query_parameters[key] == '') or  (key not in query_parameters.keys() and not dfilter.default) %}selected{% endif %}></option>
+                {% for option in dfilter.options %}
+                <option value="{{ option }}" {% if (key in query_parameters.keys() and query_parameters[key] == option) or (key not in query_parameters.keys() and dfilter.default == option) %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+              {% endif %}
             {% else %}
             <input id="{{ key }}" name="{{ key }}" type="{{ dfilter_type }}"{% if dfilter.min is defined %} min="{{ dfilter.min }}"{% endif %}{% if dfilter.max is defined %} max="{{ dfilter.max }}"{% endif %}{% if dfilter.step is defined %} step="{{ dfilter.step }}"{% endif %} value="{% if key in query_parameters.keys() %}{{ query_parameters[key] }}{% else %}{{ dfilter.default }}{% endif %}">
             {% endif %}

--- a/demo/metadata.yml
+++ b/demo/metadata.yml
@@ -51,8 +51,13 @@ plugins:
           type: select
           db: jobs
           query: SELECT DISTINCT region FROM offers_view WHERE region IS NOT NULL ORDER BY region ASC
-        search:
-          name: Search
+        company:
+          name: Company
+          type: select
+          db: jobs
+          query: SELECT DISTINCT company FROM offers_view WHERE company IS NOT NULL ORDER BY company ASC
+        job_title:
+          name: Job Title
           type: text
       charts:
         analysis-note:
@@ -99,7 +104,8 @@ plugins:
               [[ AND date <= date(:date_end) ]]
               [[ AND source = :source ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
           library: metric
           display:
             field: count
@@ -119,7 +125,8 @@ plugins:
               [[ AND date <= date(:date_end) ]]
               [[ AND source = :source ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
             GROUP BY day
             ORDER BY day
           library: vega-lite
@@ -141,7 +148,8 @@ plugins:
               [[ AND date >= date(:date_start) ]]
               [[ AND date <= date(:date_end) ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
             GROUP BY source
             ORDER BY count DESC
           library: vega-lite
@@ -171,7 +179,8 @@ plugins:
               [[ AND date >= date(:date_start) ]]
               [[ AND date <= date(:date_end) ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
             GROUP BY day, source
             ORDER BY day
           library: vega-lite
@@ -216,7 +225,8 @@ plugins:
                 [[ AND date <= date(:date_end) ]]
                 [[ AND source = :source ]]
                 [[ AND region = :region ]]
-                [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+                [[ AND company = :company ]]
+                [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
               GROUP BY
                 region
             )
@@ -265,7 +275,8 @@ plugins:
                   [[ AND date <= date(:date_end) ]]
                   [[ AND source = :source ]]
                   [[ AND region = :region ]]
-                  [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+                  [[ AND company = :company ]]
+                  [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
               ) a,
               json_each(a.array) b
             WHERE length(b.value) > 3
@@ -319,7 +330,8 @@ plugins:
               [[ AND date <= date(:date_end) ]]
               [[ AND source = :source ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
             ORDER BY date DESC
             LIMIT 5
           library: table
@@ -343,6 +355,7 @@ plugins:
               [[ AND date <= date(:date_end) ]]
               [[ AND source = :source ]]
               [[ AND region = :region ]]
-              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :search) ]]
+              [[ AND company = :company ]]
+              [[ AND id IN (SELECT rowid FROM offers_fts WHERE offers_fts MATCH :job_title) ]]
           library: map
           display:


### PR DESCRIPTION
When more than 100 options are provided, switch `select` filter to autocomplete `text` filter.

Implementation is performed using native [HTML `datalist` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist), avoiding the use of JavaScript alltogether.

Here is how it looks like in various browsers:

Firefox:
<img width="323" alt="firefox" src="https://github.com/rclement/datasette-dashboards/assets/1238873/c2dac55d-69f0-43ba-9b75-284a3a2e3f6d">

Chrome:
<img width="408" alt="chrome" src="https://github.com/rclement/datasette-dashboards/assets/1238873/265b0ce3-fe75-4c9f-9c31-45bacc9594cf">

Safari:
<img width="415" alt="safari" src="https://github.com/rclement/datasette-dashboards/assets/1238873/c9f6d44b-50c9-4075-8230-5fb8a44735ef">
